### PR TITLE
Revert "Update app/static/manifest.json"

### DIFF
--- a/app/static/manifest.json
+++ b/app/static/manifest.json
@@ -6,42 +6,6 @@
   "icons": [
     {
       "src": "/static/book_cover.png",
-      "sizes": "48x48",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/static/book_cover.png",
-      "sizes": "72x72",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/static/book_cover.png",
-      "sizes": "96x96",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/static/book_cover.png",
-      "sizes": "128x128",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/static/book_cover.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/static/book_cover.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "any"
-    },
-    {
-      "src": "/static/book_cover.png",
       "sizes": "1024x1024",
       "type": "image/png",
       "purpose": "any"


### PR DESCRIPTION
This reverts commit 7f0c0644c3044035dafd2a089c9643232e2da017, because Copilot made up files.

In the manifest, pixel graphics should have their real sizes given and the browser will then handle the rest and look for the best fitting image.
At the moment, there is just one image, but maybe in the future there will be more (or images like .ico which can hold many resolutions, or images like .svg, which do not have a resolution per se).

For reference, see: https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/icons#sizes