### PR TITLE
Add duplicate book resolution in Fast Add

### DIFF
--- a/app/routes/book_routes.py
+++ b/app/routes/book_routes.py
@@ -4854,6 +4854,7 @@ def search_books_in_library():
 def add_book_manual():
     """Manual add with series autocomplete integration (simplified)."""
     import json
+    from app.utils.category_path_utils import filter_raw_category_paths_by_visible_segments
     submit_action = request.form.get('submit_action', 'save')
     title = (request.form.get('title') or '').strip()
     if not title:
@@ -4882,13 +4883,23 @@ def add_book_manual():
             categories = [c.get('name') for c in json.loads(request.form['categories']) if c.get('name')]
         except Exception:
             pass
-    raw_categories = None
+    raw_categories_provided = 'raw_categories' in request.form
+    raw_categories: list[str] = []
     raw_cat_val = request.form.get('raw_categories')
     if raw_cat_val:
         try:
-            raw_categories = json.loads(raw_cat_val)
+            parsed = json.loads(raw_cat_val)
+            if isinstance(parsed, list):
+                raw_categories = [str(s).strip() for s in parsed if str(s).strip()]
+            elif isinstance(parsed, str) and parsed.strip():
+                raw_categories = [s.strip() for s in parsed.split(',') if s.strip()]
         except Exception:
             raw_categories = [s.strip() for s in raw_cat_val.split(',') if s.strip()]
+
+    # Defensive guard: never allow raw_categories to re-introduce categories the user removed.
+    # The UI submits category *segments* as chips; filter raw hierarchical paths to match.
+    if raw_categories and categories:
+        raw_categories = filter_raw_category_paths_by_visible_segments(raw_categories, categories)
 
     # Scalars
     # Accept multiple ISBN field names and normalize
@@ -5100,7 +5111,8 @@ def add_book_manual():
         if sd: updates['start_date']=sd
         fd = (request.form.get('finish_date') or '').strip()
         if fd: updates['finish_date']=fd
-        if raw_categories: updates['raw_categories']=raw_categories
+        if raw_categories_provided:
+            updates['raw_categories'] = raw_categories
         if updates:
             try: book_service.update_book_sync(created.uid, str(current_user.id), **updates)
             except Exception: pass

--- a/app/routes/book_routes.py
+++ b/app/routes/book_routes.py
@@ -1021,7 +1021,29 @@ def fast_add_save():
                 'success': True,
                 'message': f'Book "{title}" already exists in your library',
                 'book_id': existing_id,
-                'already_exists': True
+                'already_exists': True,
+                # Include book_data so Fast Add can offer duplicate-resolution actions
+                # via /api/resolve_duplicate (increment count / add separate / navigate).
+                'book_data': {
+                    'title': title,
+                    'author': author,
+                    'isbn13': isbn13,
+                    'isbn10': isbn10,
+                    'subtitle': subtitle,
+                    'description': description,
+                    'publisher': publisher_name,
+                    'published_date': published_date,
+                    'page_count': page_count,
+                    'language': language,
+                    'cover_url': cover_url,
+                    'categories': raw_categories if raw_categories else [],
+                    'google_books_id': (request.form.get('google_books_id') or '').strip() or None,
+                    'openlibrary_id': (request.form.get('openlibrary_id') or '').strip() or None,
+                    'reading_status': request.form.get('reading_status', ''),
+                    'ownership_status': request.form.get('ownership_status', 'owned'),
+                    'location_id': request.form.get('location_id'),
+                    'media_type': media_type
+                }
             })
         
         if not added:

--- a/app/templates/add_book.html
+++ b/app/templates/add_book.html
@@ -854,6 +854,39 @@ const FALLBACK_COVER_URL = "{{ url_for('serve_static', filename='bookshelf.png')
 // Maintain the original hierarchical category paths we derived from APIs/user input
 window.rawCategoryPaths = new Set();
 
+function normalizeCategoryName(name) {
+    return String(name || '').trim().toLowerCase();
+}
+
+function getVisibleCategoryTagNames() {
+    const names = new Set();
+    document.querySelectorAll('.category-tag').forEach(tag => {
+        const n = tag.getAttribute('data-name');
+        if (n) names.add(normalizeCategoryName(n));
+    });
+    return names;
+}
+
+// Filter raw hierarchical paths based on which segment chips are still visible.
+// If a user removes a segment chip, any raw path requiring that segment is dropped.
+function syncRawCategoryPathsWithVisibleTags() {
+    try {
+        if (!window.rawCategoryPaths || window.rawCategoryPaths.size === 0) return;
+        const visible = getVisibleCategoryTagNames();
+        const next = new Set();
+        for (const raw of window.rawCategoryPaths) {
+            const rawStr = String(raw || '').trim();
+            if (!rawStr) continue;
+            const parts = isHierarchicalCategory(rawStr) ? splitCategoryPath(rawStr) : [rawStr];
+            const keep = parts.every(p => visible.has(normalizeCategoryName(p)));
+            if (keep) next.add(rawStr);
+        }
+        window.rawCategoryPaths = next;
+    } catch (_) {
+        // best-effort sync; don't block UI
+    }
+}
+
 function isHierarchicalCategory(name) {
     return typeof name === 'string' && /[>/]/.test(name);
 }
@@ -1698,7 +1731,10 @@ function removeContributor(element) {
 }
 
 function removeCategory(element) {
+    // element is the "×" span; remove the surrounding tag
     element.parentElement.remove();
+    // Keep raw category paths consistent with visible chips
+    syncRawCategoryPathsWithVisibleTags();
 }
 
 function addContributor(type, name, id) {
@@ -2222,6 +2258,13 @@ function loadLocations() {
 }
 
 function collectContributorsAndCategories() {
+    // Remove any previously appended hidden inputs so we don't submit stale/duplicate values
+    document.querySelectorAll(
+        '#addBookForm input[type="hidden"][name^="contributors_"], ' +
+        '#addBookForm input[type="hidden"][name="categories"], ' +
+        '#addBookForm input[type="hidden"][name="raw_categories"]'
+    ).forEach(el => el.remove());
+
     // Collect all contributors
     const contributorTypes = ['authored', 'narrated', 'edited', 'translated', 'illustrated'];
     contributorTypes.forEach(type => {
@@ -2260,6 +2303,7 @@ function collectContributorsAndCategories() {
     }
 
     // Also submit raw hierarchical paths so backend can create parent/child relationships
+    syncRawCategoryPathsWithVisibleTags();
     if (window.rawCategoryPaths && window.rawCategoryPaths.size > 0) {
         const rawInput = document.createElement('input');
         rawInput.type = 'hidden';

--- a/app/templates/add_book_fast.html
+++ b/app/templates/add_book_fast.html
@@ -315,6 +315,74 @@
     </div>
 </div>
 
+<!-- Duplicate Book Resolution Modal -->
+<div class="modal fade" id="duplicateBookModal" tabindex="-1" aria-labelledby="duplicateBookModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content">
+            <div class="modal-header bg-warning">
+                <h5 class="modal-title" id="duplicateBookModalLabel">
+                    <i class="bi bi-exclamation-triangle me-2"></i>Duplicate Book Found
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-info mb-4">
+                    <i class="bi bi-info-circle me-2"></i>
+                    This book already exists in your library. How would you like to proceed?
+                </div>
+                
+                <div id="duplicateBookInfo" class="mb-4">
+                    <!-- Book info will be populated here -->
+                </div>
+                
+                <div class="d-grid gap-3">
+                    <!-- Option 1: Increment Count -->
+                    <button type="button" class="btn btn-lg btn-outline-primary text-start" id="incrementCountBtn">
+                        <div class="d-flex align-items-center">
+                            <div class="flex-shrink-0">
+                                <i class="bi bi-plus-circle fs-2 me-3"></i>
+                            </div>
+                            <div class="flex-grow-1">
+                                <div class="fw-bold">Increment Count (+1)</div>
+                                <small class="text-muted">Increase the quantity count for the existing entry</small>
+                            </div>
+                        </div>
+                    </button>
+                    
+                    <!-- Option 2: Add as Separate Entry -->
+                    <button type="button" class="btn btn-lg btn-outline-success text-start" id="addSeparateBtn">
+                        <div class="d-flex align-items-center">
+                            <div class="flex-shrink-0">
+                                <i class="bi bi-file-earmark-plus fs-2 me-3"></i>
+                            </div>
+                            <div class="flex-grow-1">
+                                <div class="fw-bold">Add as Separate Entry</div>
+                                <small class="text-muted">Create a new entry to track unique photos or notes</small>
+                            </div>
+                        </div>
+                    </button>
+                    
+                    <!-- Option 3: Navigate to Existing -->
+                    <button type="button" class="btn btn-lg btn-outline-secondary text-start" id="navigateExistingBtn">
+                        <div class="d-flex align-items-center">
+                            <div class="flex-shrink-0">
+                                <i class="bi bi-arrow-right-circle fs-2 me-3"></i>
+                            </div>
+                            <div class="flex-grow-1">
+                                <div class="fw-bold">View Existing Entry</div>
+                                <small class="text-muted">Navigate to the existing book to view or edit</small>
+                            </div>
+                        </div>
+                    </button>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <style>
 .recently-added-item {
     transition: all 0.3s ease;
@@ -447,7 +515,168 @@ document.addEventListener('DOMContentLoaded', function() {
         editModalInstance = bootstrap.Modal.getOrCreateInstance(editModalEl);
         editModalEl.addEventListener('hidden.bs.modal', cleanupStaleModalBackdrops);
     }
+
+    // Keep duplicate modal out of stacking contexts too
+    const duplicateModalEl = document.getElementById('duplicateBookModal');
+    if (duplicateModalEl) {
+        try {
+            if (duplicateModalEl.parentElement !== document.body) {
+                document.body.appendChild(duplicateModalEl);
+            }
+        } catch (e) {
+            console.warn('Failed to move duplicate modal to body:', e);
+        }
+        duplicateModalEl.addEventListener('hidden.bs.modal', cleanupStaleModalBackdrops);
+    }
 });
+
+// Duplicate handling (Fast Add)
+let currentDuplicateData = null;
+const resolveDuplicateUrl = "{{ url_for('book.resolve_duplicate') }}";
+
+function resetDuplicateButtons() {
+    const buttons = ['incrementCountBtn', 'addSeparateBtn', 'navigateExistingBtn'];
+    buttons.forEach(id => {
+        const btn = document.getElementById(id);
+        if (!btn) return;
+        btn.disabled = false;
+        if (btn.dataset.originalHtml) {
+            btn.innerHTML = btn.dataset.originalHtml;
+        }
+    });
+}
+
+function showDuplicateModal(duplicateResponse) {
+    currentDuplicateData = duplicateResponse;
+    resetDuplicateButtons();
+
+    const hasExistingId = !!(duplicateResponse && duplicateResponse.book_id);
+    const incBtn = document.getElementById('incrementCountBtn');
+    const navBtn = document.getElementById('navigateExistingBtn');
+    if (!hasExistingId) {
+        if (incBtn) incBtn.disabled = true;
+        if (navBtn) navBtn.disabled = true;
+    }
+
+    const bookData = (duplicateResponse && duplicateResponse.book_data) ? duplicateResponse.book_data : {};
+    const bookInfo = document.getElementById('duplicateBookInfo');
+    if (bookInfo) {
+        bookInfo.innerHTML = `
+            <div class="card">
+                <div class="card-body">
+                    <h6 class="card-title">${escapeHtml(bookData.title || 'Untitled')}</h6>
+                    ${bookData.author ? `<p class="card-text mb-1"><small class="text-muted">by ${escapeHtml(bookData.author)}</small></p>` : ''}
+                    ${bookData.isbn13 ? `<p class="card-text mb-0"><small>ISBN-13: ${escapeHtml(String(bookData.isbn13))}</small></p>` : ''}
+                    ${bookData.isbn10 ? `<p class="card-text mb-0"><small>ISBN-10: ${escapeHtml(String(bookData.isbn10))}</small></p>` : ''}
+                </div>
+            </div>
+        `;
+    }
+
+    cleanupStaleModalBackdrops();
+    if (!(window.bootstrap && bootstrap.Modal)) {
+        console.error('Bootstrap modal not available');
+        return;
+    }
+    const modalEl = document.getElementById('duplicateBookModal');
+    if (!modalEl) return;
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+    modal.show();
+}
+
+async function resolveDuplicate(action, btn, busyText) {
+    if (!currentDuplicateData) return;
+    if (!btn) return;
+
+    if (!btn.dataset.originalHtml) {
+        btn.dataset.originalHtml = btn.innerHTML;
+    }
+    btn.disabled = true;
+    btn.innerHTML = `<span class="spinner-border spinner-border-sm me-2"></span>${busyText}`;
+
+    try {
+        const response = await fetch(resolveDuplicateUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': getCsrfToken()
+            },
+            body: JSON.stringify({
+                action,
+                book_id: currentDuplicateData.book_id,
+                book_data: currentDuplicateData.book_data
+            }),
+            credentials: 'same-origin'
+        });
+
+        const result = await response.json();
+        if (!result.success) {
+            showIsbnNotification(result.message || 'Failed to resolve duplicate', 'error');
+            btn.disabled = false;
+            btn.innerHTML = btn.dataset.originalHtml;
+            return;
+        }
+
+        // Close duplicate modal
+        const modalEl = document.getElementById('duplicateBookModal');
+        const modal = (window.bootstrap && bootstrap.Modal) ? bootstrap.Modal.getInstance(modalEl) : null;
+        if (modal) modal.hide();
+        cleanupStaleModalBackdrops();
+
+        // Fast Add preference: keep user on page except explicit navigation
+        if (action === 'navigate' && result.redirect_url) {
+            window.location.href = result.redirect_url;
+            return;
+        }
+
+        if (action === 'add_separate' && result.book_id) {
+            // Add to recently added list
+            const bookForList = {
+                ...(currentDuplicateData.book_data || {}),
+                cover_url: (currentDuplicateData.book_data && currentDuplicateData.book_data.cover_url) ? currentDuplicateData.book_data.cover_url : FALLBACK_COVER
+            };
+            addToRecentlyAdded(bookForList, result.book_id);
+        }
+
+        showIsbnNotification(result.message || 'Updated', 'success');
+
+        // Clear current book data and return to ISBN entry
+        currentBookData = null;
+        const previewCard = document.getElementById('bookPreviewCard');
+        if (previewCard) {
+            previewCard.style.display = 'none';
+            previewCard.classList.remove('saving');
+        }
+        document.getElementById('isbnInput').focus();
+    } catch (error) {
+        console.error('Error resolving duplicate:', error);
+        showIsbnNotification('An error occurred. Please try again.', 'error');
+        btn.disabled = false;
+        btn.innerHTML = btn.dataset.originalHtml;
+    }
+}
+
+// Button handlers (duplicate modal)
+const incrementCountBtn = document.getElementById('incrementCountBtn');
+if (incrementCountBtn) {
+    incrementCountBtn.addEventListener('click', function() {
+        resolveDuplicate('increment_count', this, 'Updating...');
+    });
+}
+
+const addSeparateBtn = document.getElementById('addSeparateBtn');
+if (addSeparateBtn) {
+    addSeparateBtn.addEventListener('click', function() {
+        resolveDuplicate('add_separate', this, 'Creating...');
+    });
+}
+
+const navigateExistingBtn = document.getElementById('navigateExistingBtn');
+if (navigateExistingBtn) {
+    navigateExistingBtn.addEventListener('click', function() {
+        resolveDuplicate('navigate', this, 'Navigating...');
+    });
+}
 
 function loadSettings() {
     const settings = JSON.parse(localStorage.getItem('fastAddSettings') || '{}');
@@ -776,6 +1005,17 @@ async function saveBook() {
         
         const result = await response.json();
         
+        if (result.success && result.already_exists) {
+            previewCard.classList.remove('saving');
+
+            // Prefer server-provided book_data; fall back to our in-memory payload
+            showDuplicateModal({
+                book_id: result.book_id,
+                book_data: result.book_data || saveData
+            });
+            return;
+        }
+
         if (result.success) {
             // Add to recently added list
             addToRecentlyAdded(currentBookData, result.book_id);
@@ -881,6 +1121,40 @@ async function saveEditedBook() {
         });
         
         const result = await response.json();
+
+        if (result.success && result.already_exists) {
+            // Close edit modal before opening duplicate modal (avoids stacking/backdrop conflicts)
+            const editModalEl = document.getElementById('editModal');
+            const editModal = (window.bootstrap && bootstrap.Modal) ? bootstrap.Modal.getInstance(editModalEl) : null;
+            if (editModal) editModal.hide();
+            cleanupStaleModalBackdrops();
+
+            const bookDataForDuplicate = result.book_data || {
+                title: formData.get('title') || '',
+                author: formData.get('author') || '',
+                isbn13: formData.get('isbn13') || '',
+                isbn10: formData.get('isbn10') || '',
+                subtitle: formData.get('subtitle') || '',
+                description: formData.get('description') || '',
+                publisher: formData.get('publisher') || '',
+                published_date: formData.get('published_date') || '',
+                page_count: formData.get('page_count') || '',
+                language: formData.get('language') || 'en',
+                cover_url: formData.get('cover_url') || '',
+                categories: (currentBookData && currentBookData.categories) ? currentBookData.categories : [],
+                google_books_id: formData.get('google_books_id') || '',
+                openlibrary_id: formData.get('openlibrary_id') || '',
+                reading_status: formData.get('reading_status') || '',
+                ownership_status: formData.get('ownership_status') || 'owned',
+                location_id: formData.get('location_id') || null
+            };
+
+            showDuplicateModal({
+                book_id: result.book_id,
+                book_data: bookDataForDuplicate
+            });
+            return;
+        }
         
         if (result.success) {
             // Close modal

--- a/app/templates/add_book_fast.html
+++ b/app/templates/add_book_fast.html
@@ -395,6 +395,23 @@ let countdownInterval = null;
 let currentBookData = null;
 let recentlyAddedBooks = [];
 const FALLBACK_COVER = "{{ url_for('serve_static', filename='bookshelf.png') }}";
+let editModalInstance = null;
+
+function cleanupStaleModalBackdrops() {
+    try {
+        // Remove any leftover backdrops that can block pointer events
+        document.querySelectorAll('.modal-backdrop').forEach(el => el.remove());
+        // If no modals are currently shown, ensure body isn't stuck in modal-open state
+        const anyShown = document.querySelector('.modal.show');
+        if (!anyShown) {
+            document.body.classList.remove('modal-open');
+            document.body.style.removeProperty('padding-right');
+            document.body.style.removeProperty('overflow');
+        }
+    } catch (e) {
+        console.warn('Modal cleanup failed:', e);
+    }
+}
 
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', function() {
@@ -413,6 +430,23 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('autoSaveTimeout').addEventListener('change', saveSettings);
     document.getElementById('defaultReadingStatus').addEventListener('change', saveSettings);
     document.getElementById('defaultOwnershipStatus').addEventListener('change', saveSettings);
+
+    // Initialize and harden the edit modal against stacking-context/z-index issues
+    // (If the modal lives inside a positioned/z-indexed container, the backdrop can end up above it.)
+    const editModalEl = document.getElementById('editModal');
+    if (editModalEl) {
+        try {
+            if (editModalEl.parentElement !== document.body) {
+                document.body.appendChild(editModalEl);
+            }
+        } catch (e) {
+            console.warn('Failed to move edit modal to body:', e);
+        }
+    }
+    if (editModalEl && window.bootstrap && bootstrap.Modal) {
+        editModalInstance = bootstrap.Modal.getOrCreateInstance(editModalEl);
+        editModalEl.addEventListener('hidden.bs.modal', cleanupStaleModalBackdrops);
+    }
 });
 
 function loadSettings() {
@@ -521,6 +555,34 @@ function escapeHtml(text) {
     return String(text).replace(/[&<>"']/g, m => map[m]);
 }
 
+function cleanDescriptionText(raw) {
+    if (!raw) return '';
+    const html = String(raw);
+    try {
+        // Convert basic structure tags into newlines before parsing
+        const normalizedHtml = html
+            .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+            .replace(/<\s*\/p\s*>/gi, '\n\n')
+            .replace(/<\s*p\b[^>]*>/gi, '')
+            .replace(/<\s*li\b[^>]*>/gi, '\n- ')
+            .replace(/<\s*\/li\s*>/gi, '')
+            .replace(/<\s*\/ul\s*>/gi, '\n')
+            .replace(/<\s*\/ol\s*>/gi, '\n');
+
+        const tmp = document.createElement('div');
+        tmp.innerHTML = normalizedHtml;
+        const text = (tmp.textContent || tmp.innerText || '').trim();
+        return text
+            .replace(/\r\n/g, '\n')
+            .replace(/[ \t]+\n/g, '\n')
+            .replace(/\n{3,}/g, '\n\n')
+            .trim();
+    } catch (_) {
+        // Fallback: rough strip of tags
+        return html.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+    }
+}
+
 async function lookupISBN() {
     const isbnInput = document.getElementById('isbnInput');
     const isbn = isbnInput.value.trim().replace(/[-\s]/g, '');
@@ -578,6 +640,7 @@ async function lookupISBN() {
 }
 
 function displayBookPreview(bookData, isbn) {
+    const cleanedDescription = cleanDescriptionText(bookData.description || '');
     currentBookData = {
         title: bookData.title || '',
         author: bookData.authors ? (Array.isArray(bookData.authors) ? bookData.authors.join(', ') : bookData.authors) : '',
@@ -587,7 +650,7 @@ function displayBookPreview(bookData, isbn) {
         published_date: bookData.published_date || '',
         page_count: bookData.page_count || '',
         language: bookData.language || 'en',
-        description: bookData.description || '',
+        description: cleanedDescription,
         cover_url: bookData.cover_url || FALLBACK_COVER,
         google_books_id: bookData.google_books_id || '',
         openlibrary_id: bookData.openlibrary_id || '',
@@ -761,8 +824,17 @@ function editBook() {
     document.getElementById('editOwnershipStatus').value = settings.defaultOwnershipStatus || 'owned';
     
     // Show modal
-    const modal = new bootstrap.Modal(document.getElementById('editModal'));
-    modal.show();
+    cleanupStaleModalBackdrops();
+    const modalEl = document.getElementById('editModal');
+    if (!modalEl || !(window.bootstrap && bootstrap.Modal)) {
+        console.error('Bootstrap modal not available');
+        return;
+    }
+    if (!editModalInstance) {
+        editModalInstance = bootstrap.Modal.getOrCreateInstance(modalEl);
+        modalEl.addEventListener('hidden.bs.modal', cleanupStaleModalBackdrops);
+    }
+    editModalInstance.show();
 }
 
 function formatDateForInput(dateStr) {
@@ -812,8 +884,10 @@ async function saveEditedBook() {
         
         if (result.success) {
             // Close modal
-            const modal = bootstrap.Modal.getInstance(document.getElementById('editModal'));
-            modal.hide();
+            const modalEl = document.getElementById('editModal');
+            const modal = (window.bootstrap && bootstrap.Modal) ? bootstrap.Modal.getInstance(modalEl) : null;
+            if (modal) modal.hide();
+            cleanupStaleModalBackdrops();
             
             // Add to recently added list
             const savedData = {

--- a/app/utils/category_path_utils.py
+++ b/app/utils/category_path_utils.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Optional
+
+
+def _normalize_category_segment(value: str) -> str:
+    return (value or "").strip().lower()
+
+
+def _split_category_path(value: str) -> List[str]:
+    if not isinstance(value, str):
+        return []
+    return [part.strip() for part in re.split(r"[>/]", value) if part.strip()]
+
+
+def filter_raw_category_paths_by_visible_segments(
+    raw_category_paths: Optional[Iterable[str]],
+    visible_category_segments: Iterable[str],
+) -> List[str]:
+    """Filter hierarchical raw category paths based on visible UI segment chips.
+
+    The Add Book UI renders hierarchical paths like "Fiction > Mystery" as separate
+    chips ("Fiction", "Mystery"). If a user removes a chip, any raw path requiring
+    that segment should be dropped.
+
+    This is a defensive server-side guard in case client-side state becomes stale.
+    """
+
+    if not raw_category_paths:
+        return []
+
+    visible = {_normalize_category_segment(v) for v in visible_category_segments if _normalize_category_segment(v)}
+    if not visible:
+        return []
+
+    filtered: List[str] = []
+    for raw in raw_category_paths:
+        raw_str = (raw or "").strip()
+        if not raw_str:
+            continue
+        parts = _split_category_path(raw_str)
+        if not parts:
+            continue
+        if all(_normalize_category_segment(part) in visible for part in parts):
+            filtered.append(raw_str)
+
+    return filtered


### PR DESCRIPTION
Implement a modal for handling duplicate books in the Fast Add feature, allowing users to choose actions when a duplicate is detected. Additionally, introduce category path filtering to ensure consistency between user-selected categories and submitted data.

Fixes #174, #156