### PR TITLE
fix(templates): constrain book cover width on small screens

### DIFF
--- a/app/templates/view_book_enhanced.html
+++ b/app/templates/view_book_enhanced.html
@@ -110,7 +110,7 @@
                         <div class="col-md-4 text-center mb-3 mb-md-0">
                             <div class="position-relative d-inline-block">
                                 {% from 'macros/cover_input.html' import render_cover_display %}
-                                {{ render_cover_display(book, css_classes="img-fluid rounded shadow-sm", style="max-height: 490px; max-width: 350px; width: auto; height: auto; object-fit: contain;", img_id="book-cover") }}
+                                {{ render_cover_display(book, css_classes="img-fluid rounded shadow-sm", style="max-height: 490px; max-width: min(100%, 350px); width: auto; height: auto; object-fit: contain;", img_id="book-cover") }}
                                 {% if book.media_type and book.media_type|lower == 'audiobook' %}
                                 <span class="position-absolute bottom-0 end-0 m-2 badge rounded-pill bg-dark text-white opacity-75" title="Audiobook">
                                     <i class="bi bi-soundwave"></i>


### PR DESCRIPTION
This is small fix for issue 209 (https://github.com/pickles4evaaaa/mybibliotheca/issues/209) 

It just sets a maximum width of 100% of the container for book images in the book view. 