### PR TITLE
fix: fromisoformat error when editing reading log dates

### DIFF
--- a/app/routes/reading_log_routes.py
+++ b/app/routes/reading_log_routes.py
@@ -484,6 +484,14 @@ def edit_reading_log(log_id):
             return render_template('reading_logs/edit_log.html', log=existing_log)
         
         # Create updated reading log object
+        # Handle created_at - may already be a datetime object
+        created_at_value = existing_log.get("created_at")
+        if isinstance(created_at_value, datetime):
+            created_at = created_at_value
+        elif isinstance(created_at_value, str):
+            created_at = datetime.fromisoformat(created_at_value)
+        else:
+            created_at = datetime.now(timezone.utc)
         updated_log = ReadingLog(
             user_id=current_user.id,
             book_id=final_book_id,
@@ -491,7 +499,7 @@ def edit_reading_log(log_id):
             pages_read=pages_read,
             minutes_read=minutes_read,
             notes=notes or None,
-            created_at=datetime.fromisoformat(existing_log['created_at']) if existing_log.get('created_at') else datetime.now(timezone.utc),
+            created_at=created_at,
             updated_at=datetime.now(timezone.utc)
         )
         


### PR DESCRIPTION
Bug: when updating a readling log date, an error occurs and the update doesn't happen.

How encounterd: on the list of reading logs, click the pencil icon to edit an entry. Change the date and save the change. An error is shown on the UI and is logged on the server.

Fix: Handle case where created_at is already a datetime object rather than a string, which was causing 'argument must be str' error when editing reading logs.

Testing: tested locally with Docker - can now successfully edit reading log dates.