### PR TITLE
Fix: People card body routing under the mounted people blueprint

### DIFF
--- a/app/templates/people.html
+++ b/app/templates/people.html
@@ -199,7 +199,7 @@
                                 <div class="person-selection">
                                     <input type="checkbox" class="person-checkbox" value="{{ person.id }}" data-book-count="{{ person.book_count }}">
                                 </div>
-                                <div class="card-body" onclick="openPerson('{{ person.id }}')">
+                                <div class="card-body" data-person-url="{{ url_for('people.person_details', person_id=person.id) }}" onclick="openPerson(this.dataset.personUrl)">
                                     <div class="d-flex align-items-center mb-3">
                                         {% if person.image_url %}
                                             <img src="{{ person.image_url }}" alt="{{ person.name }}" 
@@ -792,8 +792,8 @@ function submitDeletion(selectedBoxes, forceDelete = false) {
     form.submit();
 }
 
-function openPerson(personId) {
-    window.location.href = `/person/${personId}`;
+function openPerson(personUrl) {
+    window.location.href = personUrl;
 }
 
 function updateSelection() {


### PR DESCRIPTION
## Summary
Fix the People page card-body navigation so clicking a person card resolves through the people blueprint instead of hardcoding a root-relative /person/... path.

## Root Cause
The People page template hardcoded openPerson('{{ person.id }}'), and the helper built /person/ in JavaScript. That bypassed the blueprint mount point even though the people routes are registered under /people, so card-body clicks could route to a 404.

## Changes
- Pass the Flask-generated person details URL into the card body via data-person-url
- Update openPerson() to accept a full URL and navigate directly
- Keep the change scoped to app/templates/people.html

## Impact
- Clicking the body of a person/author card now routes to the correct person details page
- Existing footer actions and other People page interactions are unchanged
- The data-person-url attribute avoids the editor/template underline issue caused by nesting Jinja inside an inline JavaScript string

## Validation
- Confirmed people_bp is registered under /people
- Confirmed person_details is routed as /person/<person_id> within that blueprint
- Re-ran a Jinja template parse check on the updated people.html: Jinja parse OK

Related to https://github.com/pickles4evaaaa/mybibliotheca/issues/244